### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## What happened?
+
+<!-- Describe the bug in 1-2 lines -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- OS:
+- VS Code version:
+- GPU:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request
+about: Suggest an idea or improvement
+labels: enhancement
+---
+
+## What would you like?
+
+<!-- Describe the feature in one sentence -->
+
+## Why?
+
+<!-- Optional: what problem does this solve? -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,8 @@
+---
+name: Question / Support
+about: Ask a question about usage or configuration
+labels: question
+---
+
+## Question
+

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -5,4 +5,3 @@ labels: question
 ---
 
 ## Question
-


### PR DESCRIPTION
## Summary

- Bug Report / Feature Request / Question の3種類のテンプレートを追加
- `blank_issues_enabled: false` で素のissueを無効化

## Test plan

- [ ] GitHub の "New issue" でテンプレート選択画面に3種類が表示される
- [ ] 各テンプレートを開きフィールドが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository metadata-only change affecting GitHub issue creation flow; no runtime code or data handling impact.
> 
> **Overview**
> Adds GitHub issue templates for **Bug Report**, **Feature Request**, and **Question/Support** with prefilled sections and default labels.
> 
> Disables creating untemplated issues by setting `blank_issues_enabled: false` in `.github/ISSUE_TEMPLATE/config.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f4fa68e5db483f269c16ad62a48bf808d82e102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->