### PR TITLE
feat: replace text labels with codicon icons in status bar

### DIFF
--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -57,7 +57,7 @@ export class StatusBarManager {
       this.cpuItem,
       'cpu',
       cpu && config.get<boolean>('showCpu', true)
-        ? `$(pulse) ${cpu.overall.toFixed(1).padStart(4)}%`
+        ? `$(chip) ${cpu.overall.toFixed(1).padStart(4)}%`
         : null,
       cpu ? buildCpuTooltip(cpu) : null,
     );
@@ -66,7 +66,7 @@ export class StatusBarManager {
       this.memItem,
       'mem',
       mem && config.get<boolean>('showMemory', true)
-        ? `$(database) ${(mem.usedBytes / 1024 / 1024 / 1024).toFixed(1)}/${(mem.totalBytes / 1024 / 1024 / 1024).toFixed(1)} GB`
+        ? `$(server) ${(mem.usedBytes / 1024 / 1024 / 1024).toFixed(1)}/${(mem.totalBytes / 1024 / 1024 / 1024).toFixed(1)} GB`
         : null,
       mem ? buildMemoryTooltip(mem) : null,
     );
@@ -74,11 +74,11 @@ export class StatusBarManager {
     let gpuText: string | null = null;
     if (gpu && config.get<boolean>('showGpu', true)) {
       if (gpu.vramUsedMB !== null && gpu.vramTotalMB !== null) {
-        gpuText = `$(server) ${(gpu.vramUsedMB / 1024).toFixed(1)}/${(gpu.vramTotalMB / 1024).toFixed(1)} GB`;
+        gpuText = `$(graph-line) ${(gpu.vramUsedMB / 1024).toFixed(1)}/${(gpu.vramTotalMB / 1024).toFixed(1)} GB`;
       } else if (gpu.vramUsedMB !== null) {
-        gpuText = `$(server) ${(gpu.vramUsedMB / 1024).toFixed(1)} GB`;
+        gpuText = `$(graph-line) ${(gpu.vramUsedMB / 1024).toFixed(1)} GB`;
       } else {
-        gpuText = `$(server) N/A`;
+        gpuText = `$(graph-line) N/A`;
       }
     }
     this.updateItem(

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -57,7 +57,7 @@ export class StatusBarManager {
       this.cpuItem,
       'cpu',
       cpu && config.get<boolean>('showCpu', true)
-        ? `CPU ${cpu.overall.toFixed(1).padStart(4)}%`
+        ? `$(pulse) ${cpu.overall.toFixed(1).padStart(4)}%`
         : null,
       cpu ? buildCpuTooltip(cpu) : null,
     );
@@ -66,7 +66,7 @@ export class StatusBarManager {
       this.memItem,
       'mem',
       mem && config.get<boolean>('showMemory', true)
-        ? `RAM ${(mem.usedBytes / 1024 / 1024 / 1024).toFixed(1)}/${(mem.totalBytes / 1024 / 1024 / 1024).toFixed(1)} GB`
+        ? `$(database) ${(mem.usedBytes / 1024 / 1024 / 1024).toFixed(1)}/${(mem.totalBytes / 1024 / 1024 / 1024).toFixed(1)} GB`
         : null,
       mem ? buildMemoryTooltip(mem) : null,
     );
@@ -74,11 +74,11 @@ export class StatusBarManager {
     let gpuText: string | null = null;
     if (gpu && config.get<boolean>('showGpu', true)) {
       if (gpu.vramUsedMB !== null && gpu.vramTotalMB !== null) {
-        gpuText = `VRAM ${(gpu.vramUsedMB / 1024).toFixed(1)}/${(gpu.vramTotalMB / 1024).toFixed(1)} GB`;
+        gpuText = `$(server) ${(gpu.vramUsedMB / 1024).toFixed(1)}/${(gpu.vramTotalMB / 1024).toFixed(1)} GB`;
       } else if (gpu.vramUsedMB !== null) {
-        gpuText = `VRAM ${(gpu.vramUsedMB / 1024).toFixed(1)} GB`;
+        gpuText = `$(server) ${(gpu.vramUsedMB / 1024).toFixed(1)} GB`;
       } else {
-        gpuText = `VRAM N/A`;
+        gpuText = `$(server) N/A`;
       }
     }
     this.updateItem(


### PR DESCRIPTION
## Summary
- ステータスバーのテキストラベル（CPU/RAM/VRAM）を VS Code Codicon アイコンに置換
  - CPU → `$(pulse)`
  - RAM → `$(database)`
  - VRAM → `$(server)`

## Test plan
- [ ] `F5` で Extension Development Host を起動し、アイコンが正しく表示されることを確認
- [ ] CPU / RAM / VRAM 各アイテムの数値が従来通り更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)